### PR TITLE
[Feature] 서버 배포를 위한 도커 컨테이너 이미지를 만드는 Dockerfile 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ src/main/java/earlybird/earlybird/user/TestController.java
 src/main/resources/key/firebase_admin_sdk_private_key.json
 
 logs/*.log
+
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:21
+ARG JAR_FILE=build/libs/earlybird-server.jar
+COPY ${JAR_FILE} app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,10 @@ repositories {
 	mavenCentral()
 }
 
+bootJar {
+	archiveFileName = "${rootProject.name}-server.jar"
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'


### PR DESCRIPTION
## 관련 이슈
- https://github.com/team-pixels-dev/EarlyBird-BE/issues/35
## 작업 내용
스프링 서버 배포를 위한 도커 컨테이너 이미지를 만드는 Dockerfile을 구현함.
이미지 빌드 후, 해당 이미지로 컨테이너를 실행할 때 환경변수 파일을 --env-file 옵션으로 지정해서 실행하도록 함.