### PR TITLE
[Deploy] GitHub Actions CD 워크플로우에서 최신 ECS 태스크 정의 ARN을 가져오도록 수정

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -9,7 +9,6 @@ env:
   ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
   ECS_SERVICE: ${{ vars.ECS_SERVICE }}
   ECS_CLUSTER: ${{ vars.ECS_CLUSTER }}
-  ECS_TASK_DEFINITION_ARN: ${{ secrets.ECS_TASK_DEFINITION_ARN }}
   CONTAINER_NAME: ${{ vars.CONTAINER_NAME }}
   DB_URL: ${{ secrets.DB_URL }}
   DB_USERNAME: ${{ secrets.DB_USERNAME }}
@@ -67,6 +66,15 @@ jobs:
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+      - name: Get Latest ECS Task Definition ARN
+        id: get-latest-task-df
+        run: |
+          LATEST_TASK_DEF=$(aws ecs describe-task-definition \
+            --task-definition earlybird-server \
+            --query 'taskDefinition.taskDefinitionArn' \
+            --output text)
+          echo "ECS_TASK_DEFINITION_ARN=$LATEST_TASK_DEF" >> $GITHUB_ENV
 
       - name: Fill in the new image ID in the Amazon ECS task definition
         id: task-def


### PR DESCRIPTION
## 관련 이슈
- https://github.com/team-pixels-dev/EarlyBird-BE/issues/47

## 작업 내용
- GitHub Actions CD 워크플로우에서 최신 ECS 태스크 정의 ARN을 가져오도록 수정