### PR TITLE
[Feature] NPS 점수 수집 시 Day 정보 함께 수집하도록 설정

### DIFF
--- a/src/main/java/earlybird/earlybird/feedback/controller/request/CreateFeedbackScoreRequest.java
+++ b/src/main/java/earlybird/earlybird/feedback/controller/request/CreateFeedbackScoreRequest.java
@@ -21,6 +21,5 @@ public class CreateFeedbackScoreRequest {
             timezone = "Asia/Seoul")
     private LocalDateTime createdAt;
 
-    @NotNull
-    private Integer dayCount;
+    @NotNull private Integer dayCount;
 }

--- a/src/main/java/earlybird/earlybird/feedback/controller/request/CreateFeedbackScoreRequest.java
+++ b/src/main/java/earlybird/earlybird/feedback/controller/request/CreateFeedbackScoreRequest.java
@@ -20,4 +20,7 @@ public class CreateFeedbackScoreRequest {
             pattern = "yyyy-MM-dd HH:mm:ss",
             timezone = "Asia/Seoul")
     private LocalDateTime createdAt;
+
+    @NotNull
+    private Integer dayCount;
 }

--- a/src/main/java/earlybird/earlybird/feedback/domain/score/FeedbackScoreDayInfo.java
+++ b/src/main/java/earlybird/earlybird/feedback/domain/score/FeedbackScoreDayInfo.java
@@ -1,0 +1,30 @@
+package earlybird.earlybird.feedback.domain.score;
+
+import earlybird.earlybird.common.BaseTimeEntity;
+import earlybird.earlybird.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+/**
+ * 피드백 점수(NPS 점수) 응답 Day 정보
+ * Day 0 = 사용자 서비스 최초 사용일
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Entity
+public class FeedbackScoreDayInfo extends BaseTimeEntity {
+    @Column(name = "feedback_score_day_info_id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long id;
+
+    private Integer day;
+
+    @OneToOne
+    @JoinColumn(name = "feedback_score_id")
+    private FeedbackScore feedbackScore;
+}

--- a/src/main/java/earlybird/earlybird/feedback/domain/score/FeedbackScoreDayInfo.java
+++ b/src/main/java/earlybird/earlybird/feedback/domain/score/FeedbackScoreDayInfo.java
@@ -1,16 +1,12 @@
 package earlybird.earlybird.feedback.domain.score;
 
 import earlybird.earlybird.common.BaseTimeEntity;
-import earlybird.earlybird.user.entity.User;
+
 import jakarta.persistence.*;
+
 import lombok.*;
 
-import java.time.LocalDateTime;
-
-/**
- * 피드백 점수(NPS 점수) 응답 Day 정보
- * Day 0 = 사용자 서비스 최초 사용일
- */
+/** 피드백 점수(NPS 점수) 응답 Day 정보 Day 0 = 사용자 서비스 최초 사용일 */
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/main/java/earlybird/earlybird/feedback/domain/score/FeedbackScoreDayInfoRepository.java
+++ b/src/main/java/earlybird/earlybird/feedback/domain/score/FeedbackScoreDayInfoRepository.java
@@ -1,0 +1,7 @@
+package earlybird.earlybird.feedback.domain.score;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.CrudRepository;
+
+public interface FeedbackScoreDayInfoRepository extends JpaRepository<FeedbackScoreDayInfo, Long> {
+}

--- a/src/main/java/earlybird/earlybird/feedback/domain/score/FeedbackScoreDayInfoRepository.java
+++ b/src/main/java/earlybird/earlybird/feedback/domain/score/FeedbackScoreDayInfoRepository.java
@@ -1,7 +1,5 @@
 package earlybird.earlybird.feedback.domain.score;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.repository.CrudRepository;
 
-public interface FeedbackScoreDayInfoRepository extends JpaRepository<FeedbackScoreDayInfo, Long> {
-}
+public interface FeedbackScoreDayInfoRepository extends JpaRepository<FeedbackScoreDayInfo, Long> {}

--- a/src/main/java/earlybird/earlybird/feedback/service/anonymous/CreateAnonymousFeedbackScoreService.java
+++ b/src/main/java/earlybird/earlybird/feedback/service/anonymous/CreateAnonymousFeedbackScoreService.java
@@ -1,6 +1,8 @@
 package earlybird.earlybird.feedback.service.anonymous;
 
 import earlybird.earlybird.feedback.domain.score.FeedbackScore;
+import earlybird.earlybird.feedback.domain.score.FeedbackScoreDayInfo;
+import earlybird.earlybird.feedback.domain.score.FeedbackScoreDayInfoRepository;
 import earlybird.earlybird.feedback.domain.score.FeedbackScoreRepository;
 import earlybird.earlybird.feedback.service.anonymous.request.CreateAnonymousFeedbackScoreServiceRequest;
 
@@ -14,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class CreateAnonymousFeedbackScoreService {
 
     private final FeedbackScoreRepository feedbackScoreRepository;
+    private final FeedbackScoreDayInfoRepository feedbackScoreDayInfoRepository;
 
     @Transactional
     public void create(CreateAnonymousFeedbackScoreServiceRequest request) {
@@ -24,6 +27,13 @@ public class CreateAnonymousFeedbackScoreService {
                         .createdTimeAtClient(request.getCreatedAt())
                         .build();
 
-        feedbackScoreRepository.save(feedbackScore);
+        FeedbackScore savedFeedbackScore = feedbackScoreRepository.save(feedbackScore);
+
+        FeedbackScoreDayInfo dayInfo = FeedbackScoreDayInfo.builder()
+                .day(request.getDayCount())
+                .feedbackScore(savedFeedbackScore)
+                .build();
+
+        feedbackScoreDayInfoRepository.save(dayInfo);
     }
 }

--- a/src/main/java/earlybird/earlybird/feedback/service/anonymous/CreateAnonymousFeedbackScoreService.java
+++ b/src/main/java/earlybird/earlybird/feedback/service/anonymous/CreateAnonymousFeedbackScoreService.java
@@ -29,10 +29,11 @@ public class CreateAnonymousFeedbackScoreService {
 
         FeedbackScore savedFeedbackScore = feedbackScoreRepository.save(feedbackScore);
 
-        FeedbackScoreDayInfo dayInfo = FeedbackScoreDayInfo.builder()
-                .day(request.getDayCount())
-                .feedbackScore(savedFeedbackScore)
-                .build();
+        FeedbackScoreDayInfo dayInfo =
+                FeedbackScoreDayInfo.builder()
+                        .day(request.getDayCount())
+                        .feedbackScore(savedFeedbackScore)
+                        .build();
 
         feedbackScoreDayInfoRepository.save(dayInfo);
     }

--- a/src/main/java/earlybird/earlybird/feedback/service/anonymous/request/CreateAnonymousFeedbackScoreServiceRequest.java
+++ b/src/main/java/earlybird/earlybird/feedback/service/anonymous/request/CreateAnonymousFeedbackScoreServiceRequest.java
@@ -12,13 +12,15 @@ public class CreateAnonymousFeedbackScoreServiceRequest {
     private int score;
     private String clientId;
     private LocalDateTime createdAt;
+    private Integer dayCount;
 
     @Builder
     private CreateAnonymousFeedbackScoreServiceRequest(
-            int score, String clientId, LocalDateTime createdAt) {
+            int score, String clientId, LocalDateTime createdAt, Integer dayCount) {
         this.score = score;
         this.clientId = clientId;
         this.createdAt = createdAt;
+        this.dayCount = dayCount;
     }
 
     public static CreateAnonymousFeedbackScoreServiceRequest of(
@@ -27,6 +29,7 @@ public class CreateAnonymousFeedbackScoreServiceRequest {
                 .score(request.getScore())
                 .clientId(request.getClientId())
                 .createdAt(request.getCreatedAt())
+                .dayCount(request.getDayCount())
                 .build();
     }
 }

--- a/src/test/java/earlybird/earlybird/feedback/service/anonymous/CreateAnonymousFeedbackScoreServiceTest.java
+++ b/src/test/java/earlybird/earlybird/feedback/service/anonymous/CreateAnonymousFeedbackScoreServiceTest.java
@@ -1,10 +1,14 @@
 package earlybird.earlybird.feedback.service.anonymous;
 
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
 import earlybird.earlybird.feedback.domain.score.FeedbackScore;
 import earlybird.earlybird.feedback.domain.score.FeedbackScoreDayInfo;
 import earlybird.earlybird.feedback.domain.score.FeedbackScoreDayInfoRepository;
 import earlybird.earlybird.feedback.domain.score.FeedbackScoreRepository;
 import earlybird.earlybird.feedback.service.anonymous.request.CreateAnonymousFeedbackScoreServiceRequest;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,30 +18,25 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
-
 @ExtendWith(MockitoExtension.class)
 class CreateAnonymousFeedbackScoreServiceTest {
 
-    @Mock
-    private FeedbackScoreRepository feedbackScoreRepository;
+    @Mock private FeedbackScoreRepository feedbackScoreRepository;
 
-    @Mock
-    private FeedbackScoreDayInfoRepository feedbackScoreDayInfoRepository;
+    @Mock private FeedbackScoreDayInfoRepository feedbackScoreDayInfoRepository;
 
-    @InjectMocks
-    private CreateAnonymousFeedbackScoreService service;
+    @InjectMocks private CreateAnonymousFeedbackScoreService service;
 
     @DisplayName("요청에 담긴 피드백 점수를 DB에 저장한다")
     @Test
     void createFeedbackScore() {
-        CreateAnonymousFeedbackScoreServiceRequest request = CreateAnonymousFeedbackScoreServiceRequest.builder()
-                .createdAt(LocalDateTime.of(2025, 3, 6, 0, 0, 0))
-                .clientId("client-id")
-                .dayCount(7)
-                .score(10)
-                .build();
+        CreateAnonymousFeedbackScoreServiceRequest request =
+                CreateAnonymousFeedbackScoreServiceRequest.builder()
+                        .createdAt(LocalDateTime.of(2025, 3, 6, 0, 0, 0))
+                        .clientId("client-id")
+                        .dayCount(7)
+                        .score(10)
+                        .build();
 
         service.create(request);
 
@@ -47,12 +46,13 @@ class CreateAnonymousFeedbackScoreServiceTest {
     @DisplayName("요청에 담긴 사용자 Day 정보를 DB에 저장한다")
     @Test
     void createFeedbackScoreDayInfo() {
-        CreateAnonymousFeedbackScoreServiceRequest request = CreateAnonymousFeedbackScoreServiceRequest.builder()
-                .createdAt(LocalDateTime.of(2025, 3, 6, 0, 0, 0))
-                .clientId("client-id")
-                .dayCount(7)
-                .score(10)
-                .build();
+        CreateAnonymousFeedbackScoreServiceRequest request =
+                CreateAnonymousFeedbackScoreServiceRequest.builder()
+                        .createdAt(LocalDateTime.of(2025, 3, 6, 0, 0, 0))
+                        .clientId("client-id")
+                        .dayCount(7)
+                        .score(10)
+                        .build();
 
         service.create(request);
 

--- a/src/test/java/earlybird/earlybird/feedback/service/anonymous/CreateAnonymousFeedbackScoreServiceTest.java
+++ b/src/test/java/earlybird/earlybird/feedback/service/anonymous/CreateAnonymousFeedbackScoreServiceTest.java
@@ -1,0 +1,61 @@
+package earlybird.earlybird.feedback.service.anonymous;
+
+import earlybird.earlybird.feedback.domain.score.FeedbackScore;
+import earlybird.earlybird.feedback.domain.score.FeedbackScoreDayInfo;
+import earlybird.earlybird.feedback.domain.score.FeedbackScoreDayInfoRepository;
+import earlybird.earlybird.feedback.domain.score.FeedbackScoreRepository;
+import earlybird.earlybird.feedback.service.anonymous.request.CreateAnonymousFeedbackScoreServiceRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CreateAnonymousFeedbackScoreServiceTest {
+
+    @Mock
+    private FeedbackScoreRepository feedbackScoreRepository;
+
+    @Mock
+    private FeedbackScoreDayInfoRepository feedbackScoreDayInfoRepository;
+
+    @InjectMocks
+    private CreateAnonymousFeedbackScoreService service;
+
+    @DisplayName("요청에 담긴 피드백 점수를 DB에 저장한다")
+    @Test
+    void createFeedbackScore() {
+        CreateAnonymousFeedbackScoreServiceRequest request = CreateAnonymousFeedbackScoreServiceRequest.builder()
+                .createdAt(LocalDateTime.of(2025, 3, 6, 0, 0, 0))
+                .clientId("client-id")
+                .dayCount(7)
+                .score(10)
+                .build();
+
+        service.create(request);
+
+        verify(feedbackScoreRepository).save(any(FeedbackScore.class));
+    }
+
+    @DisplayName("요청에 담긴 사용자 Day 정보를 DB에 저장한다")
+    @Test
+    void createFeedbackScoreDayInfo() {
+        CreateAnonymousFeedbackScoreServiceRequest request = CreateAnonymousFeedbackScoreServiceRequest.builder()
+                .createdAt(LocalDateTime.of(2025, 3, 6, 0, 0, 0))
+                .clientId("client-id")
+                .dayCount(7)
+                .score(10)
+                .build();
+
+        service.create(request);
+
+        verify(feedbackScoreDayInfoRepository).save(any(FeedbackScoreDayInfo.class));
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- https://github.com/team-pixels-dev/EarlyBird-BE/issues/52

## 작업 내용
- Day 1/3/7 리텐션 계산을 위해 NPS 점수 수집 시 Day 정보도 함께 수집하도록 설정
- 관련 테스트 코드 작성